### PR TITLE
Add support for Message Thread ID (Topics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $handler = new TelegramHandler(
     true,  // Use cURL or not? default: true = use when available
     10,    // Timeout for API requests, default: 10
     true   // Verify SSL certificate or not? default: true, false only useful for development - avoid in production
-    2,     // (optional) Target Topic ID (thread ID) for group chats
+    2,     // (optional) Target Thread ID for group chats with Topics enabled
 );
 
 $handler->setFormatter(new TelegramFormatter());    // Usage of this formatter is optional but recommended if you want better message layout

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ $handler = new TelegramHandler(
     true,  // Bubble up the stack or not, default: true
     true,  // Use cURL or not? default: true = use when available
     10,    // Timeout for API requests, default: 10
-    true   // Verify SSL certificate or not? default: true, false only useful for development - avoid in production,
-    2, // (optional) Target Topic ID (thread ID) for group chats
+    true   // Verify SSL certificate or not? default: true, false only useful for development - avoid in production
+    2,     // (optional) Target Topic ID (thread ID) for group chats
 );
 
 $handler->setFormatter(new TelegramFormatter());    // Usage of this formatter is optional but recommended if you want better message layout

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ $handler = new TelegramHandler(
     true,  // Bubble up the stack or not, default: true
     true,  // Use cURL or not? default: true = use when available
     10,    // Timeout for API requests, default: 10
-    true   // Verify SSL certificate or not? default: true, false only useful for development - avoid in production
+    true   // Verify SSL certificate or not? default: true, false only useful for development - avoid in production,
+    2, // (optional) Target Topic ID (thread ID) for group chats
 );
 
 $handler->setFormatter(new TelegramFormatter());    // Usage of this formatter is optional but recommended if you want better message layout

--- a/src/TelegramHandler.php
+++ b/src/TelegramHandler.php
@@ -80,7 +80,7 @@ class TelegramHandler extends AbstractProcessingHandler
      * @param bool      $verifyPeer Whether to use SSL certificate verification or not
      * @param int|null  $messageThreadId Thread ID for group chats with Topics feature enabled
      */
-    public function __construct(string $token, int $chatId, int|string|Level $level = Level::Debug, bool $bubble = true, bool $useCurl = true, int $timeout = 10, bool $verifyPeer = true, ?int $messageThreadId = NULL)
+    public function __construct(string $token, int $chatId, int|string|Level $level = Level::Debug, bool $bubble = true, bool $useCurl = true, int $timeout = 10, bool $verifyPeer = true, ?int $messageThreadId = null)
     {
         $this->token = $token;
         $this->chatId = $chatId;

--- a/src/TelegramHandler.php
+++ b/src/TelegramHandler.php
@@ -71,14 +71,14 @@ class TelegramHandler extends AbstractProcessingHandler
     private ?int $messageThreadId;
 
     /**
-     * @param string    $token           Telegram bot API token
-     * @param int       $chatId          Chat ID to which logs will be sent
-     * @param Level     $level           The minimum logging level at which this handler will be triggered
-     * @param bool      $bubble          Whether the messages that are handled can bubble up the stack or not
-     * @param bool      $useCurl         Whether to use cURL extension when available or not
-     * @param int       $timeout         Maximum time to wait for requests to finish
-     * @param bool      $verifyPeer      Whether to use SSL certificate verification or not
-     * @param int|null  $messageThreadId Thread ID for group chats with Topics feature enabled
+     * @param string           $token           Telegram bot API token
+     * @param int              $chatId          Chat ID to which logs will be sent
+     * @param int|string|Level $level           The minimum logging level at which this handler will be triggered
+     * @param bool             $bubble          Whether the messages that are handled can bubble up the stack or not
+     * @param bool             $useCurl         Whether to use cURL extension when available or not
+     * @param int              $timeout         Maximum time to wait for requests to finish
+     * @param bool             $verifyPeer      Whether to use SSL certificate verification or not
+     * @param int|null         $messageThreadId Thread ID for group chats with Topics feature enabled
      */
     public function __construct(string $token, int $chatId, int|string|Level $level = Level::Debug, bool $bubble = true, bool $useCurl = true, int $timeout = 10, bool $verifyPeer = true, ?int $messageThreadId = null)
     {

--- a/src/TelegramHandler.php
+++ b/src/TelegramHandler.php
@@ -71,13 +71,13 @@ class TelegramHandler extends AbstractProcessingHandler
     private ?int $messageThreadId;
 
     /**
-     * @param string    $token      Telegram bot API token
-     * @param int       $chatId     Chat ID to which logs will be sent
-     * @param Level     $level      The minimum logging level at which this handler will be triggered
-     * @param bool      $bubble     Whether the messages that are handled can bubble up the stack or not
-     * @param bool      $useCurl    Whether to use cURL extension when available or not
-     * @param int       $timeout    Maximum time to wait for requests to finish
-     * @param bool      $verifyPeer Whether to use SSL certificate verification or not
+     * @param string    $token           Telegram bot API token
+     * @param int       $chatId          Chat ID to which logs will be sent
+     * @param Level     $level           The minimum logging level at which this handler will be triggered
+     * @param bool      $bubble          Whether the messages that are handled can bubble up the stack or not
+     * @param bool      $useCurl         Whether to use cURL extension when available or not
+     * @param int       $timeout         Maximum time to wait for requests to finish
+     * @param bool      $verifyPeer      Whether to use SSL certificate verification or not
      * @param int|null  $messageThreadId Thread ID for group chats with Topics feature enabled
      */
     public function __construct(string $token, int $chatId, int|string|Level $level = Level::Debug, bool $bubble = true, bool $useCurl = true, int $timeout = 10, bool $verifyPeer = true, ?int $messageThreadId = null)


### PR DESCRIPTION
This PR adds optional support for sending messages to specific group threads. This is a feature of group chats with the Topics feature enabled.

| Parameter | Type | Required | Description |
| --- | --- | --- | --- |
| message_thread_id |	Integer	| Optional |Unique identifier for the target message thread (topic) of the forum; for forum supergroups only |

https://core.telegram.org/bots/api#sendmessage

For backward compatibility, it is added as a last parameter.