### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/src/TelegramFormatter.php
+++ b/src/TelegramFormatter.php
@@ -60,11 +60,11 @@ class TelegramFormatter implements FormatterInterface
     /**
      * Formatter constructor
      *
-     * @param bool   $html       Format as HTML or not
-     * @param string $format     The format of the message
-     * @param string $dateFormat The format of the timestamp: one supported by DateTime::format
-     * @param string $separator  Record separator used when sending batch of logs in one message
-     * @param array  $emojiArray Array containing emojis for each record level name
+     * @param bool        $html       Format as HTML or not
+     * @param string|null $format     The format of the message
+     * @param string|null $dateFormat The format of the timestamp: one supported by DateTime::format
+     * @param string      $separator  Record separator used when sending batch of logs in one message
+     * @param array|null  $emojiArray Array containing emojis for each record level name
      */
     public function __construct(bool $html = true, ?string $format = null, ?string $dateFormat = null, string $separator = '-', ?array $emojiArray = null)
     {

--- a/src/TelegramFormatter.php
+++ b/src/TelegramFormatter.php
@@ -66,7 +66,7 @@ class TelegramFormatter implements FormatterInterface
      * @param string $separator  Record separator used when sending batch of logs in one message
      * @param array  $emojiArray Array containing emojis for each record level name
      */
-    public function __construct(bool $html = true, string $format = null, string $dateFormat = null, string $separator = '-', array $emojiArray = null)
+    public function __construct(bool $html = true, ?string $format = null, ?string $dateFormat = null, string $separator = '-', ?array $emojiArray = null)
     {
         $this->html = $html;
         $this->format = $format ?: self::MESSAGE_FORMAT;


### PR DESCRIPTION
This PR fixes compatibility with PHP 8.4.

```
[24-Jan-2025 11:53:47 UTC] PHP Deprecated:  jacklul\MonologTelegramHandler\TelegramFormatter::__construct(): Implicitly marking parameter $format as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/src/TelegramFormatter.php on line 69
[24-Jan-2025 11:53:47 UTC] PHP Deprecated:  jacklul\MonologTelegramHandler\TelegramFormatter::__construct(): Implicitly marking parameter $dateFormat as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/src/TelegramFormatter.php on line 69
[24-Jan-2025 11:53:47 UTC] PHP Deprecated:  jacklul\MonologTelegramHandler\TelegramFormatter::__construct(): Implicitly marking parameter $emojiArray as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/src/TelegramFormatter.php on line 69
```